### PR TITLE
Add missing f-string prefix

### DIFF
--- a/source/msam/chalicelib/tags.py
+++ b/source/msam/chalicelib/tags.py
@@ -77,7 +77,7 @@ def update_diagrams():      # NOSONAR
                     print(f"new diagram id {view_id}")
                     diagrams.append({"name": diagram_name, "view_id": view_id})
                     settings.put_setting("diagrams", diagrams)
-                    print("created diagram id {view_id}")
+                    print(f"created diagram id {view_id}")
                 # check if this node is already on the diagram layout
                 if not layout.has_node(view_id, arn):
                     print(f"adding node {arn} to diagram id {view_id}")


### PR DESCRIPTION
This line printed the wrong thing in CW logs due to missing `f` prefix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.