### PR TITLE
Add empty Tags to ec2 node if none returned from service

### DIFF
--- a/source/msam/chalicelib/nodes.py
+++ b/source/msam/chalicelib/nodes.py
@@ -595,6 +595,8 @@ def ec2_instances(region):      # NOSONAR
                         #reformat the tags before appending to data
                         final_tags[tag["Key"]] = tag["Value"]
                         instance['Tags'] = final_tags
+                else:
+                    instance['Tags'] = {}
                 items.append(instance)
     else:
         print_no_region()


### PR DESCRIPTION
The front end [assumes](https://github.com/aws-solutions/aws-media-services-application-mapper/blob/main/source/html/js/app/ui/overlays/ec2_instance.js#L23) that EC2 always returns `Tags`, but the service will only return this in the Instance description if any tags have been set. This causes an error to appear in the browser console.

Make sure that the node discovery lambda adds an empty Tags to the EC2 Instance description when none have been returned, as is done for other services, to keep the front end sweet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
