### PR TITLE
Update buildspec nodejs to 14 from 12

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      nodejs: 12
+      nodejs: 14
       python: 3.8
     commands:
       - echo "nothing to do in install"


### PR DESCRIPTION
Update buildspec nodejs to 14 from 12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
