### PR TITLE
Added assertions to existing unit tests

### DIFF
--- a/source/events/test/test_media_events.py
+++ b/source/events/test/test_media_events.py
@@ -55,7 +55,10 @@ class TestMediaEvents(unittest.TestCase):
         with patch.object(media_events.EVENTS_TABLE, 'put_item', return_value={}):
             with patch.object(media_events.CLOUDWATCH_EVENTS_TABLE, 'put_item', return_value={}):
                 for event in mocked_events:
-                    media_events.lambda_handler(event, MagicMock())
+                    result = media_events.lambda_handler(event, MagicMock())
+                    self.assertTrue(result)
+                    self.assertTrue(media_events.EVENTS_TABLE.put_item.call_count == 2)
+                    self.assertTrue(media_events.CLOUDWATCH_EVENTS_TABLE.put_item.call_count == 2)
         
         patched_client.return_value.describe_origin_endpoint.side_effect = CLIENT_ERROR
         media_events.lambda_handler(mocked_event, MagicMock())

--- a/source/msam/test/test_app.py
+++ b/source/msam/test/test_app.py
@@ -30,12 +30,19 @@ class TestApp(unittest.TestCase):
     This class extends TestCase with testing functions
     """
 
+    def tearDown(self):
+        import app
+        app.DYNAMO_CLIENT.reset_mock()
+        app.DYNAMO_RESOURCE.reset_mock()
+
     def test_get_view_layout(self, patched_resource, patched_client):
         """
         Test the get_view_layout function
         """
         import app
         app.get_view_layout("any_view")
+        app.DYNAMO_RESOURCE.Table.assert_called_once_with('layout_table')
+        app.DYNAMO_RESOURCE.Table.return_value.query.assert_called_once()
 
     def test_delete_view_layout(self, patched_resource, patched_client):
         """
@@ -43,6 +50,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_view_layout("any_view", "node_id")
+        app.DYNAMO_RESOURCE.Table.assert_called_once_with('layout_table')
+        app.DYNAMO_RESOURCE.Table.return_value.delete_item.assert_called_once_with(Key={"view": "any_view", "id": "node_id"})
 
     def test_set_view_layout(self, patched_resource, patched_client):
         """
@@ -51,6 +60,7 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.set_view_layout()
+            app.DYNAMO_RESOURCE.Table.assert_called_once_with('layout_table')
 
     def test_delete_layout_views(self, patched_resource, patched_client):
         """
@@ -58,6 +68,11 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_layout_views()
+        app.DYNAMO_RESOURCE.Table.assert_any_call('layout_table')
+        app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.put_item.assert_called_with(Item={"id": "diagrams", "value": []})
+        app.DYNAMO_RESOURCE.Table.return_value.scan.assert_called_with(ExpressionAttributeNames={ "#v": "view", "#i": "id" }, ProjectionExpression="#v,#i")
+        
 
     def test_get_channel_list(self, patched_resource, patched_client):
         """
@@ -65,6 +80,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_channel_list()
+        app.DYNAMO_RESOURCE.Table.assert_called_once_with('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_called_once_with(Key={"id": "channels"})
 
     def test_delete_all_channels(self, patched_resource, patched_client):
         """
@@ -72,6 +89,10 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_all_channels()
+        app.DYNAMO_RESOURCE.Table.assert_any_call('channels_table')
+        app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.put_item.assert_called_once_with(Item={'id': 'channels', 'value': []})
+        app.DYNAMO_RESOURCE.Table.return_value.scan.assert_called_once_with(ProjectionExpression='channel,id')
 
     def test_set_channel_nodes(self, patched_resource, patched_client):
         """
@@ -80,6 +101,10 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.set_channel_nodes("channel_name")
+            app.DYNAMO_RESOURCE.Table.assert_any_call('channels_table')
+            app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+            app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_called_once_with(Key={'id': 'channels'})
+            app.DYNAMO_RESOURCE.Table.return_value.put_item.assert_called_once_with(Item={'id': 'channels', 'value': ['channel_name']})
 
     def test_get_channel_nodes(self, patched_resource, patched_client):
         """
@@ -87,6 +112,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_channel_nodes("channel_name")
+        app.DYNAMO_RESOURCE.Table.assert_called_once_with('channels_table')
+        app.DYNAMO_RESOURCE.Table.return_value.query.assert_called_once()
+
 
     def test_delete_channel_nodes(self, patched_resource, patched_client):
         """
@@ -94,6 +122,11 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_channel_nodes("channel_name")
+        app.DYNAMO_RESOURCE.Table.assert_any_call('channels_table')
+        app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_called_once_with(Key={'id': 'channels'})
+        app.DYNAMO_RESOURCE.Table.return_value.query.assert_called_once()
+        app.DYNAMO_RESOURCE.Table.return_value.query.return_value.get.assert_called_once_with('Items', [])
 
     def test_application_settings(self, patched_resource, patched_client):
         """
@@ -101,7 +134,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         with patch.object(app, 'app', return_value={}):
-            app.application_settings("channel_name")
+            settings = app.application_settings("channel_name")
+            self.assertEqual(settings, {})
 
     def test_cached_by_service_region(self, patched_resource, patched_client):
         """
@@ -109,6 +143,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.cached_by_service_region("service", "us-east-1")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_cached_by_service(self, patched_resource, patched_client):
         """
@@ -116,6 +153,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.cached_by_service("service")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_cached_by_arn(self, patched_resource, patched_client):
         """
@@ -123,6 +163,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.cached_by_arn("service")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_put_cached_data(self, patched_resource, patched_client):
         """
@@ -131,6 +174,8 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.put_cached_data()
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
 
     def test_delete_cached_data(self, patched_resource, patched_client):
         """
@@ -138,6 +183,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_cached_data("service")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        app.boto3.resource.return_value.Table.return_value.delete_item.assert_called_once()
 
     def test_regions(self, patched_resource, patched_client):
         """
@@ -145,6 +193,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.regions()
+        app.boto3.client.assert_called_once()
+        app.boto3.client.return_value.describe_regions.assert_called_once()
 
     def test_get_cloudwatch_alarms_region(self, patched_resource, patched_client):
         """
@@ -152,6 +202,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_cloudwatch_alarms_region("us-east-1")
+        app.boto3.client.assert_called_once()
+        app.boto3.client.return_value.describe_alarms.assert_called_once_with(AlarmTypes=['CompositeAlarm', 'MetricAlarm'])
 
     def test_incoming_cloudwatch_alarm(self, patched_resource, patched_client):
         """
@@ -159,6 +211,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.incoming_cloudwatch_alarm(MagicMock(), MagicMock())
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
 
     def test_subscribe_resource_to_alarm(self, patched_resource, patched_client):
         """
@@ -167,6 +221,8 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.subscribe_resource_to_alarm("alarm_name", "us-east-1")
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
 
     def test_unsubscribe_resource_from_alarm(self, patched_resource, patched_client):
         """
@@ -175,6 +231,8 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.unsubscribe_resource_from_alarm("alarm_name", "us-east-1")
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
 
     def test_subscribers_to_alarm(self, patched_resource, patched_client):
         """
@@ -182,6 +240,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.subscribers_to_alarm("alarm_name", "us-east-1")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_subscribed_with_state(self, patched_resource, patched_client):
         """
@@ -189,6 +250,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.subscribed_with_state("1")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_alarms_for_subscriber(self, patched_resource, patched_client):
         """
@@ -203,6 +267,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.all_subscribed_alarms()
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        app.boto3.resource.return_value.Table.return_value.scan.assert_called_once_with(ProjectionExpression="RegionAlarmName")
 
     def test_delete_alarm_subscriptions(self, patched_resource, patched_client):
         """
@@ -210,6 +277,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_alarm_subscriptions()
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        app.boto3.resource.return_value.Table.return_value.scan.assert_called_once_with(ProjectionExpression="RegionAlarmName,ResourceArn")
 
     def test_get_cloudwatch_events_state(self, patched_resource, patched_client):
         """
@@ -217,6 +287,10 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_cloudwatch_events_state("set")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('events_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
+        app.boto3.resource.return_value.Table.return_value.query.return_value.get.assert_called_once_with('Items', [])
 
     def test_get_cloudwatch_events_state_source(self, patched_resource, patched_client):
         """
@@ -224,6 +298,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_cloudwatch_events_state_source("set", "source")
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('events_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_get_cloudwatch_events_resource_arn(self, patched_resource, patched_client):
         """
@@ -232,6 +309,9 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.get_cloudwatch_events_resource_arn("arn")
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('cw_table')
+            app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_get_cloudwatch_events_resource_arn_start(self, patched_resource, patched_client):
         """
@@ -240,6 +320,9 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.get_cloudwatch_events_resource_arn_start("arn", 0)
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('cw_table')
+            app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_get_cloudwatch_events_resource_arn_start_end(self, patched_resource, patched_client):
         """
@@ -248,13 +331,21 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.get_cloudwatch_events_resource_arn_start_end("arn", 0, 0)
+            app.boto3.resource.assert_called_once()
+            app.boto3.resource.return_value.Table.assert_called_once_with('cw_table')
+            app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_ping(self, patched_resource, patched_client):
         """
         Test the ping function
         """
         import app
-        app.ping()
+        response = app.ping()
+        self.assertEqual(response, {
+            "message": "pong",
+            "buildstamp": '1234567890',
+            "version": 'v1.0.0'
+        })
 
     def test_update_nodes(self, patched_resource, patched_client):
         """
@@ -262,6 +353,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.update_nodes(MagicMock(), MagicMock())
+        app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': 'inventory-regions'})
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': 'cache-next-region'})
 
     def test_update_connections(self, patched_resource, patched_client):
         """
@@ -269,6 +363,7 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.update_connections(MagicMock(), MagicMock())
+        self.assertEqual(app.boto3.resource.call_count, 68)
 
     def test_update_from_tags(self, patched_resource, patched_client):
         """
@@ -276,6 +371,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.update_from_tags(MagicMock(), MagicMock())
+        self.assertEqual(app.boto3.resource.call_count, 2)
+        self.assertEqual(app.boto3.resource.return_value.Table.call_count, 2)
 
     def test_ssm_run_command(self, patched_resource, patched_client):
         """
@@ -283,6 +380,11 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.ssm_run_command(MagicMock(), MagicMock())
+        app.boto3.resource.assert_called_once()
+        app.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        app.boto3.resource.return_value.Table.return_value.query.assert_called_once()
+        app.boto3.client.assert_called_once()
+        app.boto3.client.return_value.list_documents.assert_called_once_with(Filters=[{'Key': 'tag:MSAM-NodeType', 'Values': ['ElementalLive']}, {'Key': 'Owner', 'Values': ['Self']}])
 
     def test_process_ssm_run_command(self, patched_resource, patched_client):
         """
@@ -290,6 +392,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.process_ssm_run_command(MagicMock(), MagicMock())
+        self.assertEqual(app.boto3.client.call_count, 2)
+        app.boto3.client.return_value.get_log_events.assert_called_once()
+        app.boto3.client.return_value.put_metric_data.assert_called_once()
 
     def test_update_ssm_nodes(self, patched_resource, patched_client):
         """
@@ -297,6 +402,9 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.update_ssm_nodes(MagicMock(), MagicMock())
+        app.DYNAMO_RESOURCE.Table.assert_any_call('settings_table')
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': 'inventory-regions'})
+        app.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': 'ssm-cache-next-region'})
 
     def test_generate_metrics(self, patched_resource, patched_client):
         """
@@ -304,13 +412,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.generate_metrics(MagicMock(), MagicMock())
-
-    # def test_report_metrics(self, patched_resource, patched_client):
-    #     """
-    #     Test the report_metrics function
-    #     """
-    #     import app
-    #     app.report_metrics(MagicMock(), MagicMock())
+        app.boto3.client.assert_called_once()
+        self.assertEqual(app.boto3.client.return_value.put_metric_data.call_count, 14)
 
     def test_get_resource_notes(self, patched_resource, patched_client):
         """
@@ -318,6 +421,7 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.get_resource_notes("arn")
+        app.DYNAMO_RESOURCE.Table.return_value.query.assert_called_once()
 
     def test_all_notes(self, patched_resource, patched_client):
         """
@@ -325,6 +429,8 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.all_notes()
+        app.DYNAMO_RESOURCE.Table.return_value.scan.assert_called_once()
+        app.DYNAMO_RESOURCE.Table.return_value.scan.return_value.get.assert_called_once_with('Items', [])
 
     def test_update_resource_notes(self, patched_resource, patched_client):
         """
@@ -333,6 +439,7 @@ class TestApp(unittest.TestCase):
         import app
         with patch.object(app, 'app', return_value={}):
             app.update_resource_notes("arn")
+            app.DYNAMO_RESOURCE.Table.return_value.put_item.assert_called_once()
 
     def test_delete_resource_notes(self, patched_resource, patched_client):
         """
@@ -340,6 +447,7 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_resource_notes("arn")
+        app.DYNAMO_RESOURCE.Table.return_value.delete_item.assert_called_once_with(Key={'resource_arn': 'arn'})
 
     def test_delete_all_notes(self, patched_resource, patched_client):
         """
@@ -354,3 +462,4 @@ class TestApp(unittest.TestCase):
         """
         import app
         app.delete_all_resource_notes(MagicMock(), MagicMock())
+        app.DYNAMO_RESOURCE.Table.return_value.scan.assert_called_once_with(ProjectionExpression='resource_arn')

--- a/source/msam/test/test_cache.py
+++ b/source/msam/test/test_cache.py
@@ -37,6 +37,7 @@ class TestCache(unittest.TestCase):
     This class extends TestCase with testing functions
     """
 
+
     def setUp(self):
         TESTCASE_STATE['exception_raised'] = False
 
@@ -50,6 +51,9 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.cached_by_service(SERVICE)
+        cache.boto3.resource.assert_called_once()
+        cache.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        cache.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     @patch('os.environ')
     @patch('boto3.session.Session.resource', new=boto_resource_error)
@@ -73,6 +77,9 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.cached_by_service_region(SERVICE, REGION)
+        cache.boto3.resource.assert_called_once()
+        cache.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        cache.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     @patch('os.environ')
     @patch('boto3.session.Session.resource', new=boto_resource_error)
@@ -95,6 +102,9 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.cached_by_arn(ARN)
+        cache.boto3.resource.assert_called_once()
+        cache.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        cache.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     @patch('os.environ')
     @patch('boto3.session.Session.resource', new=boto_resource_error)
@@ -116,6 +126,8 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.regions()
+        cache.boto3.client.assert_called_once()
+        cache.boto3.client.return_value.describe_regions.assert_called_once()
 
     @patch('os.environ')
     @patch('boto3.resource')
@@ -128,6 +140,8 @@ class TestCache(unittest.TestCase):
         request_obj = MagicMock()
         request_obj.json_body = [{"expires": 1657658393, "updated": 1657658399}]
         cache.put_cached_data(request_obj)
+        cache.boto3.resource.assert_called_once()
+        cache.boto3.resource.return_value.Table.assert_called_once_with('content_table')
         
     @patch('os.environ')
     @patch('boto3.session.Session.resource', new=boto_resource_error)
@@ -150,6 +164,9 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.delete_cached_data(ARN)
+        cache.boto3.resource.assert_called_once()
+        cache.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        cache.boto3.resource.return_value.Table.return_value.delete_item.assert_called_once()
 
     @patch('os.environ')
     @patch('boto3.session.Session.resource', new=boto_resource_error)
@@ -160,3 +177,4 @@ class TestCache(unittest.TestCase):
         """
         from chalicelib import cache
         cache.delete_cached_data(ARN)
+        self.assertTrue(internal_exception_raised())

--- a/source/msam/test/test_cloudwatch.py
+++ b/source/msam/test/test_cloudwatch.py
@@ -43,13 +43,16 @@ class TestCloudWatch(unittest.TestCase):
         from chalicelib import cloudwatch
         # no namespace
         cloudwatch.update_alarm_records(REGION, {"AlarmName": "TestAlarm"}, [])
+        cloudwatch.boto3.resource.assert_called_once_with('dynamodb', config=cloudwatch.MSAM_BOTO3_CONFIG)
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        cloudwatch.boto3.resource.reset_mock()
 
         mock_table = MagicMock()
         mock_table.put_item.return_value = {}
         patched_resource.return_value.Table.return_value = mock_table
         # with namespace
         cloudwatch.update_alarm_records(REGION, ALARM, [ARN])
-        
+        cloudwatch.boto3.resource.return_value.Table.return_value.put_item.assert_called_once()
         # exception
         mock_table.put_item.side_effect = CLIENT_ERROR
         cloudwatch.update_alarm_records(REGION, ALARM, [ARN])
@@ -65,7 +68,21 @@ class TestCloudWatch(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.describe_alarms.return_value = {"CompositeAlarms": [ALARM], "MetricAlarms": [ALARM]}
         patched_client.return_value = mock_obj
+        original_method = cloudwatch.update_alarm_records
+        cloudwatch.update_alarm_records = MagicMock()
         cloudwatch.update_alarm_subscriber(REGION, ALARM, SUBSCRIBER)
+        cloudwatch.boto3.client.assert_called_once_with(
+            'cloudwatch',
+            region_name=REGION,
+            config=cloudwatch.MSAM_BOTO3_CONFIG
+        )
+        self.assertEqual(cloudwatch.update_alarm_records.call_count, 2)
+        cloudwatch.update_alarm_records.assert_any_call(
+            'us-west-2',
+            ALARM,
+            [SUBSCRIBER]
+        )
+        cloudwatch.update_alarm_records = original_method
         
         mock_obj.describe_alarms.side_effect = CLIENT_ERROR
         cloudwatch.update_alarm_subscriber(REGION, ALARM, SUBSCRIBER)
@@ -81,7 +98,16 @@ class TestCloudWatch(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.describe_alarms.return_value = {"CompositeAlarms": [ALARM], "MetricAlarms": [ALARM]}
         patched_client.return_value = mock_obj
+        original_method = cloudwatch.update_alarm_records
+        cloudwatch.update_alarm_records = MagicMock()
         cloudwatch.update_alarms(REGION, [ALARM])
+        self.assertEqual(cloudwatch.update_alarm_records.call_count, 2)
+        cloudwatch.update_alarm_records.assert_any_call(
+            'us-west-2',
+            ALARM,
+            []
+        )
+        cloudwatch.update_alarm_records = original_method
 
         mock_obj.describe_alarms.side_effect = CLIENT_ERROR
         cloudwatch.update_alarms(REGION, [ALARM])
@@ -98,7 +124,18 @@ class TestCloudWatch(unittest.TestCase):
         mock_table = MagicMock()
         mock_table.query.return_value = ITEMS
         patched_resource.return_value.Table.return_value = mock_table
-        cloudwatch.alarms_for_subscriber(SUBSCRIBER)
+        items = cloudwatch.alarms_for_subscriber(SUBSCRIBER)
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.query.assert_called_once()
+        self.assertEqual(items, [
+            {
+                'Region': 'region',
+                'AlarmName': 'alarm',
+                'RegionAlarmName': 'region:alarm',
+                'ResourceArn': 'some-arn'
+            }
+        ])
 
         mock_table.query.side_effect = CLIENT_ERROR
         cloudwatch.alarms_for_subscriber(SUBSCRIBER)
@@ -114,7 +151,13 @@ class TestCloudWatch(unittest.TestCase):
         mock_table = MagicMock()
         mock_table.scan.return_value = ITEMS
         patched_resource.return_value.Table.return_value = mock_table
-        cloudwatch.all_subscribed_alarms()
+        alarms = cloudwatch.all_subscribed_alarms()
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        self.assertEqual(alarms, [{
+            'Region': 'region',
+            'AlarmName': 'alarm'
+        }])
         
         mock_table.scan.side_effect = CLIENT_ERROR
         cloudwatch.all_subscribed_alarms()
@@ -137,7 +180,8 @@ class TestCloudWatch(unittest.TestCase):
         mock_obj = MagicMock()
         mock_obj.describe_alarms.return_value =  {"CompositeAlarms": [ALARM], "MetricAlarms": [ALARM]}
         patched_client.return_value = mock_obj
-        cloudwatch.get_cloudwatch_alarms_region(REGION)
+        alarms = cloudwatch.get_cloudwatch_alarms_region(REGION)
+        self.assertEqual(len(alarms), 2)
 
         mock_obj.describe_alarms.side_effect = CLIENT_ERROR
         cloudwatch.get_cloudwatch_alarms_region(REGION)
@@ -150,6 +194,9 @@ class TestCloudWatch(unittest.TestCase):
         """
         from chalicelib import cloudwatch
         cloudwatch.get_cloudwatch_events_state("set")
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('events_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_get_cloudwatch_events_state_source(self, patched_env,
                                                 patched_resource,
@@ -159,15 +206,9 @@ class TestCloudWatch(unittest.TestCase):
         """
         from chalicelib import cloudwatch
         cloudwatch.get_cloudwatch_events_state_source("set", SOURCE)
-
-    # def test_get_cloudwatch_events_state_groups(self, patched_env,
-    #                                             patched_resource,
-    #                                             patched_client):
-    #     """
-    #     Test the get_cloudwatch_events_state_groups function
-    #     """
-    #     from chalicelib import cloudwatch
-    #     cloudwatch.get_cloudwatch_events_state_groups("set")
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('events_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.query.assert_called_once()
 
     def test_get_cloudwatch_events_resource(self, patched_env,
                                             patched_resource, patched_client):
@@ -180,6 +221,7 @@ class TestCloudWatch(unittest.TestCase):
         patched_resource.return_value.Table.return_value = mock_table
         cloudwatch.get_cloudwatch_events_resource(ARN, 1, 0)
         cloudwatch.get_cloudwatch_events_resource(ARN, 1, 1)
+        self.assertEqual(cloudwatch.boto3.resource.return_value.Table.return_value.query.call_count, 2)
 
         mock_table.query.side_effect = CLIENT_ERROR
         cloudwatch.get_cloudwatch_events_resource(ARN)
@@ -195,6 +237,7 @@ class TestCloudWatch(unittest.TestCase):
         EVENT = {"Records": [{"Sns": {"TopicArn": SNS_ARN, "Message": "\"this message\""}}]}
         with patch.object(cloudwatch, 'subscribers_to_alarm', return_value=[SUBSCRIBER]):
             cloudwatch.incoming_cloudwatch_alarm(EVENT, None)
+            self.assertEqual(cloudwatch.boto3.resource.return_value.Table.return_value.put_item.call_count, 1)
         #exception
         with patch.object(cloudwatch, 'subscribers_to_alarm', side_effect=CLIENT_ERROR):
             cloudwatch.incoming_cloudwatch_alarm(EVENT, None)
@@ -208,7 +251,8 @@ class TestCloudWatch(unittest.TestCase):
         from chalicelib import cloudwatch
         request_obj = MagicMock()
         request_obj.json_body = [ARN]
-        cloudwatch.subscribe_resource_to_alarm(request_obj, "alarm", REGION)
+        resources = cloudwatch.subscribe_resource_to_alarm(request_obj, "alarm", REGION)
+        self.assertTrue(resources)
 
         mock_table = MagicMock()
         mock_table.put_item.side_effect = CLIENT_ERROR
@@ -225,7 +269,11 @@ class TestCloudWatch(unittest.TestCase):
         mock_table = MagicMock()
         mock_table.query.return_value = {"Items": [{"ResourceArn": ARN}, {"ResourceArn": ARN}]}
         patched_resource.return_value.Table.return_value = mock_table
-        cloudwatch.subscribed_with_state("ALARM")
+        resources = cloudwatch.subscribed_with_state("ALARM")
+        self.assertEqual(resources, [{
+            'ResourceArn': 'arn:msam:user-defined-node:global:111122223333:10AA8D40-2B6F-44FA-AA67-6B909F8B1DB9',
+            'AlarmCount': 2
+        }])
 
         mock_table.query.side_effect = CLIENT_ERROR
         cloudwatch.subscribed_with_state("ALARM")
@@ -241,6 +289,9 @@ class TestCloudWatch(unittest.TestCase):
         mock_table.query.return_value = {"Items": [{"ResourceArn": ARN}]}
         patched_resource.return_value.Table.return_value = mock_table
         cloudwatch.subscribers_to_alarm("TestAlarm", REGION)
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.query.assert_called_once()
         
         mock_table.query.side_effect = CLIENT_ERROR
         cloudwatch.subscribers_to_alarm("TestAlarm", REGION)
@@ -255,13 +306,18 @@ class TestCloudWatch(unittest.TestCase):
 
         request_obj = MagicMock()
         request_obj.json_body = [ARN]
-        cloudwatch.unsubscribe_resource_from_alarm(request_obj, "alarm", REGION)
+        result = cloudwatch.unsubscribe_resource_from_alarm(request_obj, "alarm", REGION)
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.delete_item.assert_called_once()
+        self.assertTrue(result)
 
         mock_table = MagicMock()
         mock_table.delete_item.side_effect = CLIENT_ERROR
         patched_resource.return_value.Table.return_value = mock_table
-        cloudwatch.unsubscribe_resource_from_alarm(request_obj, "alarm", REGION)
+        result = cloudwatch.unsubscribe_resource_from_alarm(request_obj, "alarm", REGION)
         self.assertRaises(ClientError)        
+        self.assertFalse(result)
         
     def test_delete_all_subscriptions(self, patched_env, patched_resource,
                                       patched_client):
@@ -272,8 +328,13 @@ class TestCloudWatch(unittest.TestCase):
         mock_table = MagicMock()
         mock_table.scan.return_value = ITEMS
         patched_resource.return_value.Table.return_value = mock_table
-        cloudwatch.delete_all_subscriptions()
+        result = cloudwatch.delete_all_subscriptions()
+        cloudwatch.boto3.resource.assert_called_once()
+        cloudwatch.boto3.resource.return_value.Table.assert_called_once_with('alarms_table')
+        cloudwatch.boto3.resource.return_value.Table.return_value.delete_item.assert_called_once()
+        self.assertEqual(result, {'message': 'done'})
         
         mock_table.scan.side_effect = CLIENT_ERROR
-        cloudwatch.delete_all_subscriptions()
+        result = cloudwatch.delete_all_subscriptions()
+        self.assertTrue('error' in result['message'])
         self.assertRaises(ClientError)

--- a/source/msam/test/test_connections.py
+++ b/source/msam/test/test_connections.py
@@ -206,10 +206,16 @@ class TestConnections(unittest.TestCase):
         from chalicelib import connections, cache
         # first side effect is the return for eml input, second is for ems
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_INPUTS, CACHED_MS_CONTAINERS)):
-            connections.mediastore_container_medialive_input_ddb_items()
+            items = connections.mediastore_container_medialive_input_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer:arn:aws:medialive:us-west-2:1234567890:input:1183363')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer')
+            self.assertEqual(items[0]['to'], 'arn:aws:medialive:us-west-2:1234567890:input:1183363')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediastore_container_medialive_input_ddb_items()
+            items = connections.mediastore_container_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_medialive_channel_mediapackage_channel_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -218,12 +224,19 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_MP_CHANNELS)):
-            connections.medialive_channel_mediapackage_channel_ddb_items()
+            items = connections.medialive_channel_mediapackage_channel_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336:arn:aws:mediapackage:us-west-2:1234567890:channels/286eb42a8bf44695a44bdb48e4fb6f3f:0')
+            self.assertEqual(items[0]['from'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediapackage:us-west-2:1234567890:channels/286eb42a8bf44695a44bdb48e4fb6f3f')
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS_2, CACHED_MP_CHANNELS)):
-            connections.medialive_channel_mediapackage_channel_ddb_items()
+            items = connections.medialive_channel_mediapackage_channel_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_mediapackage_channel_ddb_items()
+            items = connections.medialive_channel_mediapackage_channel_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_medialive_channel_mediastore_container_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -232,10 +245,15 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_MS_CONTAINERS)):
-            connections.medialive_channel_mediastore_container_ddb_items()
+            items = connections.medialive_channel_mediastore_container_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336:arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer')
+            self.assertEqual(items[0]['from'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_mediastore_container_ddb_items()
+            items = connections.medialive_channel_mediastore_container_ddb_items()
+            self.assertEqual(len(items), 0)
 
 
     def test_medialive_channel_multiplex_ddb_items(self, patched_env, patched_resource,
@@ -245,10 +263,15 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_MULTIPLEX)):
-            connections.medialive_channel_multiplex_ddb_items()
+            items = connections.medialive_channel_multiplex_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336:arn:aws:medialive:us-east-1:1234567890:multiplex:2911217:0')
+            self.assertEqual(items[0]['from'], 'arn:aws:medialive:us-west-2:1234567890:channel:7678336')
+            self.assertEqual(items[0]['to'], 'arn:aws:medialive:us-east-1:1234567890:multiplex:2911217')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_multiplex_ddb_items()
+            items = connections.medialive_channel_multiplex_ddb_items()
+            self.assertEqual(len(items), 0)
 
 
     def test_medialive_input_medialive_channel_ddb_items(self, patched_env, patched_resource,
@@ -258,10 +281,12 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_ML_INPUTS)):
-            connections.medialive_input_medialive_channel_ddb_items()
+            items = connections.medialive_input_medialive_channel_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_input_medialive_channel_ddb_items()
+            items = connections.medialive_input_medialive_channel_ddb_items()
+            self.assertEqual(len(items), 0)
 
 
     def test_mediapackage_channel_mediapackage_endpoint_ddb_items(self, patched_env, patched_resource,
@@ -271,10 +296,16 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MP_CHANNELS, CACHED_MP_ENDPOINTS)):
-            connections.mediapackage_channel_mediapackage_endpoint_ddb_items()
+            items = connections.mediapackage_channel_mediapackage_endpoint_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediapackage:us-west-2:1234567890:channels/286eb42a8bf44695a44bdb48e4fb6f3f:arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediapackage:us-west-2:1234567890:channels/286eb42a8bf44695a44bdb48e4fb6f3f')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediapackage_channel_mediapackage_endpoint_ddb_items()
+            items = connections.mediapackage_channel_mediapackage_endpoint_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_multiplex_mediaconnect_flow_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -283,10 +314,15 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MULTIPLEX, CACHED_MC_FLOWS)):
-            connections.multiplex_mediaconnect_flow_ddb_items()
+            items = connections.multiplex_mediaconnect_flow_ddb_items()
+            self.assertEqual(items[0]['arn'], 'arn:aws:medialive:us-east-1:1234567890:multiplex:2911217:arn:aws:mediaconnect:us-east-1:1234567890:flow:1-WVZVV1IMAQhXBVEI-c67d3528bbe6:Plex-Test-Out-0')
+            self.assertEqual(items[0]['from'], 'arn:aws:medialive:us-east-1:1234567890:multiplex:2911217')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediaconnect:us-east-1:1234567890:flow:1-WVZVV1IMAQhXBVEI-c67d3528bbe6:Plex-Test-Out-0')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.multiplex_mediaconnect_flow_ddb_items()
+            items = connections.multiplex_mediaconnect_flow_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_s3_bucket_cloudfront_distribution_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -295,10 +331,15 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_S3, CACHED_CLOUDFRONT)):
-            connections.s3_bucket_cloudfront_distribution_ddb_items()
+            items = connections.s3_bucket_cloudfront_distribution_ddb_items()
+            self.assertEqual(items[0]['arn'], 'arn:aws:s3:::msam-upgrader-browserappmodu-msambrowserappbucket-1f8ur1bq93ntv:arn:aws:cloudfront::1234567890:distribution/E2EFYSTWYTFJBN')
+            self.assertEqual(items[0]['from'], 'arn:aws:s3:::msam-upgrader-browserappmodu-msambrowserappbucket-1f8ur1bq93ntv')
+            self.assertEqual(items[0]['to'], 'arn:aws:cloudfront::1234567890:distribution/E2EFYSTWYTFJBN')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.s3_bucket_cloudfront_distribution_ddb_items()
+            items = connections.s3_bucket_cloudfront_distribution_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_s3_bucket_medialive_input_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -307,10 +348,13 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_S3, CACHED_ML_INPUTS)):
-            connections.s3_bucket_medialive_input_ddb_items()
+            items = connections.s3_bucket_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.s3_bucket_medialive_input_ddb_items()
+            items = connections.s3_bucket_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_cloudfront_distribution_medialive_input_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -319,10 +363,13 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_CLOUDFRONT, CACHED_ML_INPUTS)):
-            connections.cloudfront_distribution_medialive_input_ddb_items()
+            items = connections.cloudfront_distribution_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.cloudfront_distribution_medialive_input_ddb_items()
+            items = connections.cloudfront_distribution_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediapackage_endpoint_cloudfront_distribution_by_tag_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -331,10 +378,15 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_CLOUDFRONT, CACHED_MP_CHANNELS, CACHED_MP_ENDPOINTS)):
-            connections.mediapackage_endpoint_cloudfront_distribution_by_tag_ddb_items()
+            items = connections.mediapackage_endpoint_cloudfront_distribution_by_tag_ddb_items()
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3:arn:aws:cloudfront::1234567890:distribution/E2EFYSTWYTFJBN')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3')
+            self.assertEqual(items[0]['to'], 'arn:aws:cloudfront::1234567890:distribution/E2EFYSTWYTFJBN')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediapackage_endpoint_cloudfront_distribution_by_tag_ddb_items()
+            items = connections.mediapackage_endpoint_cloudfront_distribution_by_tag_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediapackage_endpoint_cloudfront_distribution_by_origin_url_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -343,10 +395,12 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_CLOUDFRONT, CACHED_MP_ENDPOINTS)):
-            connections.mediapackage_endpoint_cloudfront_distribution_by_origin_url_ddb_items()
+            items = connections.mediapackage_endpoint_cloudfront_distribution_by_origin_url_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediapackage_endpoint_cloudfront_distribution_by_origin_url_ddb_items()
+            items = connections.mediapackage_endpoint_cloudfront_distribution_by_origin_url_ddb_items()
+            self.assertEqual(len(items), 0)
 
 
     def test_mediapackage_endpoint_speke_keyserver_ddb_items(self, patched_env, patched_resource,
@@ -356,10 +410,14 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_SPEKE, CACHED_MP_ENDPOINTS)):
-            connections.mediapackage_endpoint_speke_keyserver_ddb_items()
+            items = connections.mediapackage_endpoint_speke_keyserver_ddb_items()
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3:arn:oss:speke:::714958406217327359')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3')
+            self.assertEqual(items[0]['to'], 'arn:oss:speke:::714958406217327359')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediapackage_endpoint_speke_keyserver_ddb_items()
+            items = connections.mediapackage_endpoint_speke_keyserver_ddb_items()
+            self.assertEqual(len(items), 0)
 
 
     def test_mediaconnect_flow_medialive_input_ddb_items(self, patched_env, patched_resource,
@@ -369,10 +427,13 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MC_FLOWS, CACHED_ML_INPUTS)):
-            connections.mediaconnect_flow_medialive_input_ddb_items()
+            items = connections.mediaconnect_flow_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediaconnect_flow_medialive_input_ddb_items()
+            items = connections.mediaconnect_flow_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediaconnect_flow_mediaconnect_flow_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -381,10 +442,16 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MC_FLOWS, CACHED_MC_FLOWS)):
-            connections.mediaconnect_flow_mediaconnect_flow_ddb_items()
+            items = connections.mediaconnect_flow_mediaconnect_flow_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediaconnect:us-east-1:1234567890:entitlement:1-CAVaVVRQUAMLAF0P-43e6ff4eb1d4:Multiplex-2911217-pipeline-0:arn:aws:mediaconnect:us-east-1:1234567890:flow:1-WVZVV1IMAQhXBVEI-c67d3528bbe6:Plex-Test-Out-0')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediaconnect:us-east-1:1234567890:entitlement:1-CAVaVVRQUAMLAF0P-43e6ff4eb1d4:Multiplex-2911217-pipeline-0')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediaconnect:us-east-1:1234567890:flow:1-WVZVV1IMAQhXBVEI-c67d3528bbe6:Plex-Test-Out-0')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediaconnect_flow_mediaconnect_flow_ddb_items()
+            items = connections.mediaconnect_flow_mediaconnect_flow_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediapackage_endpoint_mediatailor_configuration_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -393,10 +460,16 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MP_ENDPOINTS, CACHED_MT_CONFIG)):
-            connections.mediapackage_endpoint_mediatailor_configuration_ddb_items()
+            items = connections.mediapackage_endpoint_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3:arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediapackage:us-west-2:1234567890:origin_endpoints/9d9f3e3bf04c44efb7e0fc806a546fc3')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediapackage_endpoint_mediatailor_configuration_ddb_items()
+            items = connections.mediapackage_endpoint_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediastore_container_mediatailor_configuration_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -405,10 +478,16 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_MT_CONFIG, CACHED_MS_CONTAINERS)):
-            connections.mediastore_container_mediatailor_configuration_ddb_items()
+            items = connections.mediastore_container_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer:arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
+            self.assertEqual(items[0]['from'], 'arn:aws:mediastore:us-west-2:1234567890:container/mytestcontainer')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediastore_container_mediatailor_configuration_ddb_items()
+            items = connections.mediastore_container_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_s3_bucket_mediatailor_configuration_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -417,10 +496,16 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_S3, CACHED_MT_CONFIG)):
-            connections.s3_bucket_mediatailor_configuration_ddb_items()
+            items = connections.s3_bucket_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0]['arn'], 'arn:aws:s3:::msam-upgrader-browserappmodu-msambrowserappbucket-1f8ur1bq93ntv:arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
+            self.assertEqual(items[0]['from'], 'arn:aws:s3:::msam-upgrader-browserappmodu-msambrowserappbucket-1f8ur1bq93ntv')
+            self.assertEqual(items[0]['to'], 'arn:aws:mediatailor:us-west-2:1234567890:playbackConfiguration/MyTestCampaign')
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.s3_bucket_mediatailor_configuration_ddb_items()
+            items = connections.s3_bucket_mediatailor_configuration_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_mediastore_container_cloudfront_distribution_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -429,10 +514,13 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_CLOUDFRONT, CACHED_MS_CONTAINERS)):
-            connections.mediastore_container_cloudfront_distribution_ddb_items()
+            items = connections.mediastore_container_cloudfront_distribution_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.mediastore_container_cloudfront_distribution_ddb_items()
+            items = connections.mediastore_container_cloudfront_distribution_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_medialive_channel_s3_bucket_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -441,22 +529,12 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_S3)):
-            connections.medialive_channel_s3_bucket_ddb_items()
+            items = connections.medialive_channel_s3_bucket_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_s3_bucket_ddb_items()
-
-    # def test_link_device_medialive_input_ddb_items(self, patched_env, patched_resource,
-    #                                        patched_client):
-    #     """
-    #     Test the link_device_medialive_input_ddb_items function
-    #     """
-    #     from chalicelib import connections, cache
-    #     with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_S3)):
-    #         connections.link_device_medialive_input_ddb_items()
-    #     # exception
-    #     with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-    #         connections.link_device_medialive_input_ddb_items()
+            items = connections.medialive_channel_s3_bucket_ddb_items()
+            self.assertEqual(len(items), 0)
 
     def test_medialive_channel_medialive_input_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -465,10 +543,13 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_ML_INPUTS)):
-            connections.medialive_channel_medialive_input_ddb_items()
+            items = connections.medialive_channel_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_medialive_input_ddb_items()
+            items = connections.medialive_channel_medialive_input_ddb_items()
+            self.assertEqual(len(items), 0)
+
 
     def test_medialive_channel_mediaconnect_flow_ddb_items(self, patched_env, patched_resource,
                                            patched_client):
@@ -477,7 +558,9 @@ class TestConnections(unittest.TestCase):
         """
         from chalicelib import connections, cache
         with patch.object(cache, 'cached_by_service', side_effect=(CACHED_ML_CHANNELS, CACHED_MC_FLOWS)):
-            connections.medialive_channel_mediaconnect_flow_ddb_items()
+            items = connections.medialive_channel_mediaconnect_flow_ddb_items()
+            self.assertEqual(len(items), 0)
         # exception
         with patch.object(cache, 'cached_by_service', side_effect=CLIENT_ERROR):
-            connections.medialive_channel_mediaconnect_flow_ddb_items()
+            items = connections.medialive_channel_mediaconnect_flow_ddb_items()
+            self.assertEqual(len(items), 0)

--- a/source/msam/test/test_content.py
+++ b/source/msam/test/test_content.py
@@ -21,4 +21,8 @@ class TestContent(unittest.TestCase):
         Test the put_ddb_item function
         """
         from chalicelib import content
-        content.put_ddb_items("us-east-1")
+        content.put_ddb_items(["us-east-1"])
+        content.boto3.resource.assert_called_once()
+        content.boto3.resource.return_value.Table.assert_called_once_with('content_table')
+        content.boto3.resource.return_value.Table.return_value.put_item.assert_called_once_with(Item='us-east-1')
+        print()

--- a/source/msam/test/test_db.py
+++ b/source/msam/test/test_db.py
@@ -18,6 +18,17 @@ class TestDb(unittest.TestCase):
     This class extends TestCase with testing functions
     """
 
+    def assertion_helper(self, lambda_function):
+        """
+        Helper function to run repetitive assertion statements
+        """
+        lambda_function.boto3.client.assert_called_once()
+        lambda_function.boto3.client.return_value.describe_regions.assert_called_once_with()
+        lambda_function.boto3.resource.assert_called_once()
+        lambda_function.boto3.resource.return_value.Table.assert_called_once_with('settings_table')
+        lambda_function.boto3.resource.return_value.Table.return_value.get_item.assert_called_once_with(Key={"id": "never-cache-regions"})
+        self.assertEqual(lambda_function.boto3.resource.return_value.Table.return_value.put_item.call_count, 9)
+
     def test_create_update(self, patched_client, patched_resource, patched_env):
         """
         Test the create_udpate function
@@ -25,6 +36,8 @@ class TestDb(unittest.TestCase):
         from db import lambda_function
         mocked_event = {"ResourceProperties": {"SettingsTable": "settings_table"}}
         lambda_function.create_update(mocked_event, MagicMock())
+        self.assertion_helper(lambda_function)
+
     
     def test_lambda_handler(self, patched_client, patched_resource, patched_env):
         """
@@ -34,6 +47,7 @@ class TestDb(unittest.TestCase):
         mocked_event = {"ResourceProperties": {"SettingsTable": "settings_table"}}
         with patch.object(lambda_function, 'helper'):
             lambda_function.lambda_handler(mocked_event, MagicMock())
+            lambda_function.helper.assert_called_once()
     
     def test_make_default_settings(self, patched_client, patched_resource, patched_env):
         """
@@ -41,6 +55,10 @@ class TestDb(unittest.TestCase):
         """
         from db import lambda_function
         lambda_function.make_default_settings("settings_table")
+        self.assertion_helper(lambda_function)
+        lambda_function.boto3.client.reset_mock()
+        lambda_function.boto3.resource.reset_mock()
 
         patched_resource.return_value.Table.return_value.put_item.side_effect = CLIENT_ERROR
         lambda_function.make_default_settings("settings_table")
+        self.assertion_helper(lambda_function)

--- a/source/msam/test/test_nodes.py
+++ b/source/msam/test/test_nodes.py
@@ -68,7 +68,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 's3_buckets', return_value=[{"Name": "mybucket"}]):
-            nodes.s3_bucket_ddb_items()
+            items = nodes.s3_bucket_ddb_items()
+            self.assertEqual(len(items), 1)
 
 
     def test_cloudfront_distribution_ddb_items(self, patched_env, patched_resource,
@@ -78,7 +79,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'cloudfront_distributions', return_value=[{"ARN": "some-arn"}]):
-            nodes.cloudfront_distribution_ddb_items()
+            items = nodes.cloudfront_distribution_ddb_items()
+            self.assertEqual(len(items), 1)
 
     def test_medialive_channel_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -87,7 +89,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'medialive_channels', return_value=[{"Arn": "some-arn"}]):
-            nodes.medialive_channel_ddb_items("us-east-1")
+            items = nodes.medialive_channel_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_medialive_input_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -96,7 +99,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'medialive_inputs', return_value=[{"Arn": "some-arn"}]):
-            nodes.medialive_input_ddb_items("us-east-1")
+            items = nodes.medialive_input_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_medialive_multiplex_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -105,7 +109,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'medialive_multiplexes', return_value=[{"Arn": "some-arn"}]):
-            nodes.medialive_multiplex_ddb_items("us-east-1")
+            items = nodes.medialive_multiplex_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_mediapackage_channel_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -114,7 +119,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'mediapackage_channels', return_value=[{"Arn": "some-arn"}]):
-            nodes.mediapackage_channel_ddb_items("us-east-1")
+            items = nodes.mediapackage_channel_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_mediapackage_origin_endpoint_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -123,7 +129,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'mediapackage_origin_endpoints', return_value=[{"Arn": "some-arn"}]):
-            nodes.mediapackage_origin_endpoint_ddb_items("us-east-1")
+            items = nodes.mediapackage_origin_endpoint_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_mediastore_container_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -132,7 +139,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'mediastore_containers', return_value=[{"ARN": "some-arn"}]):
-            nodes.mediastore_container_ddb_items("us-east-1")
+            items = nodes.mediastore_container_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_mediaconnect_flow_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -141,7 +149,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'mediaconnect_flows', return_value=[{"FlowArn": "some-arn"}]):
-            nodes.mediaconnect_flow_ddb_items("us-east-1")
+            items = nodes.mediaconnect_flow_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
 
     def test_mediatailor_configuration_ddb_items(self, patched_env, patched_resource,
@@ -151,7 +160,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'mediatailor_configurations', return_value=[{"PlaybackConfigurationArn": "some-arn"}]):
-            nodes.mediatailor_configuration_ddb_items("us-east-1")
+            items = nodes.mediatailor_configuration_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_ssm_managed_instance_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -160,7 +170,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'ssm_managed_instances', return_value=[{"Id": "some-arn"}]):
-            nodes.ssm_managed_instance_ddb_items("us-east-1")
+            items = nodes.ssm_managed_instance_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_ec2_instance_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -169,7 +180,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'ec2_instances', return_value=[{"InstanceId": "some-arn"}]):
-            nodes.ec2_instance_ddb_items("us-east-1")
+            items = nodes.ec2_instance_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_link_device_ddb_items(self, patched_env, patched_resource,
                                        patched_client):
@@ -178,7 +190,8 @@ class TestNodes(unittest.TestCase):
         """
         from chalicelib import nodes
         with patch.object(nodes, 'link_devices', return_value=[{"Arn": "some-arn"}]):
-            nodes.link_device_ddb_items("us-east-1")
+            items = nodes.link_device_ddb_items("us-east-1")
+            self.assertEqual(len(items), 1)
 
     def test_node_to_ddb_item(self, patched_env, patched_resource,
                                        patched_client):
@@ -186,7 +199,11 @@ class TestNodes(unittest.TestCase):
         Test the node_to_ddb_item function
         """
         from chalicelib import nodes
-        nodes.node_to_ddb_item("this-arn", "medialive", "us-east-1", {"data": "value"})
+        item = nodes.node_to_ddb_item("this-arn", "medialive", "us-east-1", {"data": "value"})
+        self.assertEqual(item['arn'], 'this-arn')
+        self.assertEqual(item['region'], 'us-east-1')
+        self.assertEqual(item['service'], 'medialive')
+        self.assertEqual(item['data'], '{"data": "value"}')
 
     def test_cloudfront_distributions(self, patched_env, patched_resource,
                                        patched_client):
@@ -196,10 +213,12 @@ class TestNodes(unittest.TestCase):
         from chalicelib import nodes
         patched_client.return_value.list_distributions.return_value = {"DistributionList": {"Items": [{"ARN": ARN, "LastModifiedTime": "time"}]}}
         patched_client.return_value.list_tags_for_resource.return_value = {'Tags': {'Items': [{'Key': 'string', 'Value': 'string'}]}}
-        nodes.cloudfront_distributions()
+        items = nodes.cloudfront_distributions()
+        self.assertEqual(len(items), 1)
 
         patched_client.return_value.list_tags_for_resource.side_effect = CLIENT_ERROR
-        nodes.cloudfront_distributions()
+        items = nodes.cloudfront_distributions()
+        self.assertEqual(len(items), 1)
 
     def test_s3_buckets(self, patched_env, patched_resource,
                                        patched_client):
@@ -209,10 +228,12 @@ class TestNodes(unittest.TestCase):
         from chalicelib import nodes
         patched_client.return_value.list_buckets.return_value = {"Buckets": [{"Name": "BucketName", "CreationDate": "time"}]}
         patched_client.return_value.get_bucket_tagging.return_value = {'TagSet': [{'Key': 'string', 'Value': 'string'}]}
-        nodes.s3_buckets()
+        buckets = nodes.s3_buckets()
+        self.assertEqual(len(buckets), 1)
 
         patched_client.return_value.get_bucket_tagging.side_effect = CLIENT_ERROR
-        nodes.s3_buckets()
+        buckets = nodes.s3_buckets()
+        self.assertEqual(len(buckets), 1)
 
     def test_mediapackage_channels(self, patched_env, patched_resource,
                                        patched_client):
@@ -224,7 +245,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_channels.side_effect =[{"Channels": ["channelA"], "NextToken": "token"},
                 {"Channels": ["channelA"]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.mediapackage_channels(REGION)
+            items = nodes.mediapackage_channels(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_mediapackage_origin_endpoints(self, patched_env, patched_resource,
                                        patched_client):
@@ -236,7 +258,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_origin_endpoints.side_effect = [{"OriginEndpoints": ["channelA"], "NextToken": "token"},
         {"OriginEndpoints": ["channelA"]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.mediapackage_origin_endpoints(REGION)
+            items = nodes.mediapackage_origin_endpoints(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_medialive_channels(self, patched_env, patched_resource,
                                        patched_client):
@@ -248,7 +271,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_channels.side_effect = [{"Channels": ["channelA"], "NextToken": "token"},
             {"Channels": ["channelA"]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.medialive_channels(REGION)
+            items = nodes.medialive_channels(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_medialive_inputs(self, patched_env, patched_resource,
                                        patched_client):
@@ -260,7 +284,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_inputs.side_effect = [{"Inputs": ["channelA"], "NextToken": "token"},
             {"Inputs": ["channelA"]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.medialive_inputs(REGION)
+            items = nodes.medialive_inputs(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_medialive_multiplexes(self, patched_env, patched_resource,
                                        patched_client):
@@ -273,7 +298,8 @@ class TestNodes(unittest.TestCase):
             {"Multiplexes": [{"Id": "channelA"}]}]
         patched_client.return_value.describe_multiplex.side_effect = [{"ResponseMetadata":"data"}, {"ResponseMetadata":"data"}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.medialive_multiplexes(REGION)
+            items = nodes.medialive_multiplexes(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_mediastore_containers(self, patched_env, patched_resource,
                                        patched_client):
@@ -285,7 +311,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_containers.side_effect = [{"Containers": [{"ARN": ARN, "CreationTime": "time"}], "NextToken": "token"},
             {"Containers": [{"ARN": ARN , "CreationTime": "time"}]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.mediastore_containers(REGION)
+            items = nodes.mediastore_containers(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_mediaconnect_flows(self, patched_env, patched_resource,
                                        patched_client):
@@ -297,7 +324,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_flows.side_effect =  [{"Flows": [{"FlowArn": ARN}], "NextToken": "token"},
             {"Flows": [{"FlowArn": ARN}]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.mediaconnect_flows(REGION)
+            items = nodes.mediaconnect_flows(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_mediatailor_configurations(self, patched_env, patched_resource,
                                        patched_client):
@@ -309,7 +337,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_playback_configurations.side_effect =  [{"Items": [{"Name": ARN}], "NextToken": "token"},
             {"Items": [{"Name": ARN}]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.mediatailor_configurations(REGION)
+            items = nodes.mediatailor_configurations(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_ssm_managed_instances(self, patched_env, patched_resource,
                                        patched_client):
@@ -321,7 +350,8 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.get_inventory.side_effect =  [{"Entities": [{"Id": "mi-instance"}], "NextToken": "token"},
             {"Entities": [{"Id": "mi-instance"}]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.ssm_managed_instances(REGION)
+            items = nodes.ssm_managed_instances(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_ec2_instances(self, patched_env, patched_resource,
                                        patched_client):
@@ -352,7 +382,8 @@ class TestNodes(unittest.TestCase):
             }]
         }]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.ec2_instances(REGION)
+            items = nodes.ec2_instances(REGION)
+            self.assertEqual(len(items), 2)
 
     def test_link_devices(self, patched_env, patched_resource,
                                        patched_client):
@@ -364,4 +395,5 @@ class TestNodes(unittest.TestCase):
         patched_client.return_value.list_input_devices.side_effect =  [{"InputDevices": [{"Id": "mi-instance"}], "NextToken": "token"},
             {"InputDevices": [{"Id": "mi-instance"}]}]
         with patch.object(boto3.Session, 'get_available_regions', return_value = [REGION]):
-            nodes.link_devices(REGION)
+            items = nodes.link_devices(REGION)
+            self.assertEqual(len(items), 2)

--- a/source/msam/test/test_notes.py
+++ b/source/msam/test/test_notes.py
@@ -29,9 +29,15 @@ class TestNotes(unittest.TestCase):
         from chalicelib import notes
         with patch.object(notes.NOTES_TABLE, 'scan', side_effect=[ITEMS_WITH_TOKEN, ITEMS]):
             with patch.object(notes.NOTES_TABLE, 'delete_item', return_value = {}):
-                notes.delete_all_notes()
+                result = notes.delete_all_notes()
+                notes.NOTES_TABLE.delete_item.assert_any_call(Key={"resource_arn": "THIS-IS-NOT-AN-ARN"})
+                notes.NOTES_TABLE.scan.assert_any_call(ProjectionExpression="resource_arn")
+                notes.NOTES_TABLE.scan.assert_any_call(ProjectionExpression="resource_arn", ExclusiveStartKey="somekey")
+                self.assertEqual(result, { 'message': 'all notes deleted' })
         with patch.object(notes.NOTES_TABLE, 'scan', side_effect=CLIENT_ERROR):
-            notes.delete_all_notes()
+            result = notes.delete_all_notes()
+            notes.NOTES_TABLE.scan.assert_called_once()
+            self.assertTrue("exception" in result)
 
     def test_get_resource_notes(self, patched_env, patched_resource,
                               patched_client):
@@ -40,10 +46,14 @@ class TestNotes(unittest.TestCase):
         """
         from chalicelib import notes
         with patch.object(notes.NOTES_TABLE, 'query', return_value=ITEMS):
-            notes.get_resource_notes(ARN)
+            result = notes.get_resource_notes(ARN)
+            self.assertEqual(result, [NOTE])
+            notes.NOTES_TABLE.query.assert_called_once()
         
         with patch.object(notes.NOTES_TABLE, 'query', side_effect=CLIENT_ERROR):
-            notes.get_resource_notes(ARN)
+            result = notes.get_resource_notes(ARN)
+            notes.NOTES_TABLE.query.assert_called_once()
+            self.assertEqual(result, [])
         self.assertRaises(ClientError)
 
     def test_get_all_notes(self, patched_env, patched_resource,
@@ -53,9 +63,15 @@ class TestNotes(unittest.TestCase):
         """
         from chalicelib import notes
         with patch.object(notes.NOTES_TABLE, 'scan', side_effect=[ITEMS_WITH_TOKEN, ITEMS]):
-            notes.get_all_notes()
+            result = notes.get_all_notes()
+            self.assertEqual(result, [NOTE, NOTE])
+            self.assertEqual(notes.NOTES_TABLE.scan.call_count, 2)
+            notes.NOTES_TABLE.scan.assert_any_call()
+            notes.NOTES_TABLE.scan.assert_any_call(ExclusiveStartKey="somekey")
         with patch.object(notes.NOTES_TABLE, 'scan', side_effect=CLIENT_ERROR):
-            notes.get_all_notes()
+            result = notes.get_all_notes()
+            self.assertEqual(result, [])
+            notes.NOTES_TABLE.scan.assert_called_once()
         self.assertRaises(ClientError)
 
 
@@ -68,7 +84,9 @@ class TestNotes(unittest.TestCase):
         mocked_notes = MagicMock()
         notes.update_resource_notes(ARN, mocked_notes)
         with patch.object(notes.NOTES_TABLE, 'put_item', side_effect=CLIENT_ERROR):
-            notes.update_resource_notes(ARN, mocked_notes)
+            result = notes.update_resource_notes(ARN, mocked_notes)
+            notes.NOTES_TABLE.put_item.assert_called_once()
+            self.assertTrue("exception" in result)
 
     def test_delete_resource_notes(self, patched_env, patched_resource,
                                   patched_client):
@@ -77,7 +95,9 @@ class TestNotes(unittest.TestCase):
         """
         from chalicelib import notes
         with patch.object(notes.NOTES_TABLE, 'delete_item', side_effect=CLIENT_ERROR):
-            notes.delete_resource_notes(ARN)
+            result = notes.delete_resource_notes(ARN)
+            notes.NOTES_TABLE.delete_item.assert_called_once()
+            self.assertTrue("exception" in result)
 
     def test_delete_all_notes_proxy(self, patched_env, patched_resource,
                                   patched_client):
@@ -87,3 +107,4 @@ class TestNotes(unittest.TestCase):
         from chalicelib import notes
         with patch.object(notes.LAMBDA_CLIENT, 'invoke', side_effect=CLIENT_ERROR):
             notes.delete_all_notes_proxy()
+            notes.LAMBDA_CLIENT.invoke.assert_called_once_with(FunctionName='some_function', InvocationType='Event')

--- a/source/msam/test/test_settings.py
+++ b/source/msam/test/test_settings.py
@@ -20,6 +20,11 @@ class TestSettings(unittest.TestCase):
     This class extends TestCase with testing functions
     """
 
+    def setUp(self):
+        from chalicelib import settings
+        settings.DYNAMO_RESOURCE.reset_mock()
+        settings.DYNAMO_RESOURCE.Table.return_value.put_item.reset_mock()
+
     def test_put_setting(self, patched_env, patched_resource,
                              patched_client):
         """
@@ -27,6 +32,7 @@ class TestSettings(unittest.TestCase):
         """
         from chalicelib import settings
         settings.put_setting(KEY, VALUE)
+        settings.DYNAMO_RESOURCE.Table.return_value.put_item.assert_called_once_with(Item={"id": KEY, "value": VALUE})
 
     def test_get_setting(self, patched_env, patched_resource, patched_client):
         """
@@ -34,15 +40,19 @@ class TestSettings(unittest.TestCase):
         """
         from chalicelib import settings
         settings.get_setting(KEY)
-
-        mock_table = MagicMock()
-        mock_table.get_item.return_value = {"Item": {"value": VALUE}}
-        patched_resource.return_value.Table.return_value = mock_table
-        settings.get_setting(KEY)
-
-        mock_table.get_item.side_effect = CLIENT_ERROR
-        patched_resource.return_value.Table.return_value = mock_table
-        settings.get_setting(KEY)
+        settings.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': KEY})
+        
+        table_mock = MagicMock()
+        table_mock.get_item.return_value = {"Item": {"value": VALUE}}
+        with patch.object(settings.DYNAMO_RESOURCE, 'Table', return_value=table_mock):
+            setting = settings.get_setting(KEY)
+            settings.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': KEY})
+            self.assertEqual(setting, 'value')
+        
+        with patch.object(settings.DYNAMO_RESOURCE.Table.return_value, 'get_item', side_effect=CLIENT_ERROR):
+            setting = settings.get_setting(KEY)
+            settings.DYNAMO_RESOURCE.Table.return_value.get_item.assert_any_call(Key={'id': KEY})
+            self.assertEqual(setting, None)
 
 
     def test_application_settings(self, patched_env, patched_resource, patched_client):
@@ -52,11 +62,23 @@ class TestSettings(unittest.TestCase):
         from chalicelib import settings
         mocked_req = MagicMock()
         mocked_req.method = "PUT"
+        put_setting_mock = MagicMock()
+        original_put_setting = settings.put_setting
+        settings.put_setting = put_setting_mock
         settings.application_settings(mocked_req, KEY)
+        settings.put_setting.assert_called_once()
+        settings.put_setting = original_put_setting
         mocked_req.method = "DELETE"
         settings.application_settings(mocked_req, KEY)
+        settings.DYNAMO_RESOURCE.Table.assert_called_once_with('settings_table')
+        settings.DYNAMO_RESOURCE.Table.return_value.delete_item.assert_any_call(Key={'id': KEY})
         mocked_req.method = "GET"
+        get_setting_mock = MagicMock()
+        original_get_setting = settings.get_setting
+        settings.get_setting = get_setting_mock
         settings.application_settings(mocked_req, KEY)
-        
+        settings.get_setting.assert_called_once()
+        settings.get_setting = original_get_setting
         with patch.object(settings, 'get_setting', side_effect=CLIENT_ERROR):
-            settings.application_settings(mocked_req, KEY)
+            result = settings.application_settings(mocked_req, KEY)
+            self.assertTrue("exception" in result)

--- a/source/msam/test/test_tags.py
+++ b/source/msam/test/test_tags.py
@@ -34,6 +34,15 @@ class TestTags(unittest.TestCase):
                     side_effect=ClientError({"Error": {"Code": "400", "Message": "SomeClientError"}}, "get_setting")):
             tags.update_diagrams()
             self.assertRaises(ClientError)
+        self.assertEqual(tags.boto3.resource.call_count, 3)
+        tags.boto3.resource.assert_any_call('dynamodb', config=tags.MSAM_BOTO3_CONFIG)
+        self.assertEqual(tags.boto3.resource.return_value.Table.call_count, 3)
+        tags.boto3.resource.return_value.Table.assert_any_call('content_table')
+        self.assertEqual(tags.boto3.resource.return_value.Table.return_value.scan.call_count, 3)
+        tags.boto3.resource.return_value.Table.return_value.scan.assert_any_call(
+            FilterExpression="contains(#data, :tagname)",
+            ExpressionAttributeNames={"#data": "data"},
+            ExpressionAttributeValues={":tagname": "MSAM-Diagram"})
 
     @patch('os.environ')
     @patch('boto3.resource')
@@ -50,10 +59,18 @@ class TestTags(unittest.TestCase):
         patched_resource.return_value.Table.return_value = mock_table
         tags.update_tiles()
 
-        # 
         with patch.object(channels, 'get_channel_nodes', return_value = [{"name": "new-tile", "id": "newtile"}]):
             tags.update_tiles()
         with patch.object(channels, 'get_channel_nodes', 
                     side_effect=ClientError({"Error": {"Code": "400", "Message": "SomeClientError"}}, "get_channel_nodes")):
             tags.update_tiles()
             self.assertRaises(ClientError)
+        self.assertEqual(tags.boto3.resource.call_count, 3)
+        tags.boto3.resource.assert_any_call('dynamodb', config=tags.MSAM_BOTO3_CONFIG)
+        self.assertEqual(tags.boto3.resource.return_value.Table.call_count, 3)
+        tags.boto3.resource.return_value.Table.assert_any_call('content_table')
+        self.assertEqual(tags.boto3.resource.return_value.Table.return_value.scan.call_count, 3)
+        tags.boto3.resource.return_value.Table.return_value.scan.assert_any_call(
+            FilterExpression="contains(#data, :tagname)",
+            ExpressionAttributeNames={"#data": "data"},
+            ExpressionAttributeValues={":tagname": "MSAM-Tile"})


### PR DESCRIPTION
Background
==========
Having 80% minimum coverage on Unit tests is one of the criteria for the solution to meet the Quality bar. Although the solution had the required coverage, a lot of the tests were missing assertion statements.

Changes
=======
* Added assertion statements to all test cases missing them

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
