### PR TITLE
Update connections.py

### DIFF
--- a/source/msam/chalicelib/connections.py
+++ b/source/msam/chalicelib/connections.py
@@ -246,7 +246,6 @@ def medialive_channel_mediapackage_channel_ddb_items():
             # if setting is empty, we have to connect medialive with mediapackage via channel ID
             if destination["MediaPackageSettings"]:
                 items += ml_to_mp_via_channel_id(ml_channel_data, destination, mediapackage_ch_cached, ml_service_name)
-                break
             # otherwise we check via URL endpoints
             items += ml_to_mp_via_url(ml_channel_data, destination, mediapackage_ch_cached, ml_service_name)
     except ClientError as error:
@@ -766,7 +765,6 @@ def mediaconnect_flow_medialive_input_ddb_items():
                         flow_data["FlowArn"],
                         flow_output["MediaLiveInputArn"],
                         connection_type, config))
-                break
             # for each output, look for the matching MediaLive input
             medialive_in_cached = cache.cached_by_service("medialive-input")
             # iterate over all medialive inputs


### PR DESCRIPTION
fixed connection issue between media live and others

I used this MSAM application for monitoring several media services of AWS. 
While using it, I noticed that it showed connection correctly only one flow logic of (media connect - media live input - media live channel - media package). And it didn't work for others.

I checked the source code and found that the 'break' statement of 'for' statement only run the first index of array and stop running of rest of arrays.

So I removed the 'break' statement and all services are connected.